### PR TITLE
Cps 175 upstream 4.1 merge

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -83,7 +83,7 @@ jobs:
         run: composer install --prefer-dist --no-progress --no-interaction
 
       - name: Run phpstan
-        run: /vendor/bin/phpstan analyse --memory-limit=-1 -c phpstan.neon
+        run: ./vendor/bin/phpstan analyse --memory-limit=-1 -c phpstan.neon
 
   sonarcloud:
     runs-on: ubuntu-latest

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "source": "https://github.com/workivate/php-saml/"
     },
     "require": {
-        "php": ">=8.1",
+        "php": "^8.1",
         "robrichards/xmlseclibs": ">=3.1.1"
     },
     "require-dev": {


### PR DESCRIPTION
[CPS-175](https://workivate.atlassian.net/browse/CPS-175)

Try to resolve GitHub actions that run when merging into Master. This is not part of the upstream, but rather seems to be a LifeWorks thing. Fix typo that we only found when we get to Master 🙁 

Also change how we specify the PHP version to match LifeWorks standards